### PR TITLE
Add item autocomplete endpoint and improve schema tagging

### DIFF
--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -16,7 +16,7 @@ from .serializers import LoginSerializer, LogoutSerializer, LogoutResponseSerial
 
 
 User = get_user_model()
-
+@extend_schema(tags=['Authentication'])
 class AuthViewSet(viewsets.ViewSet):
     serializer_action_classes = {
         'login':   LoginSerializer,
@@ -31,7 +31,6 @@ class AuthViewSet(viewsets.ViewSet):
     @extend_schema(
         request=LoginSerializer,
         responses={200: TokenResponseSerializer},
-        tags=['Authentication']
     )
     def login(self, request):
         serializer = LoginSerializer(data=request.data)
@@ -62,7 +61,6 @@ class AuthViewSet(viewsets.ViewSet):
     @extend_schema(
         request=TokenRefreshSerializer,
         responses={200: AccessSerializer},
-        tags=['Authentication']
     )
     def refresh(self, request):
         serializer = TokenRefreshSerializer(data=request.data)
@@ -80,7 +78,7 @@ class AuthViewSet(viewsets.ViewSet):
     @extend_schema(
         request=LogoutSerializer,
         responses={200: LogoutResponseSerializer},
-        auth=['bearerAuth'], tags=['Authentication']
+        auth=['bearerAuth'],
     )
     def logout(self, request):
         serializer = LogoutSerializer(data=request.data)

--- a/backend/reports/serializers.py
+++ b/backend/reports/serializers.py
@@ -203,3 +203,6 @@ class DeliveryReportSerializer(serializers.ModelSerializer):
             )
 
         return report
+
+class ItemAutocompleteFilterSerializer(serializers.Serializer):
+    q = serializers.CharField(required=True, min_length=2, help_text="Search term for item name")

--- a/backend/reports/urls.py
+++ b/backend/reports/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import DeliveryReportViewSet, HomePageView
+from .views import DeliveryReportViewSet, HomePageView, ItemAutocompleteView
 
 router = DefaultRouter()
 router.register(r'delivery-reports', DeliveryReportViewSet, basename='deliveryreport')
 
 urlpatterns = [
     path('', HomePageView.as_view(), name='home'),# Homepage at root of app
-    path('api/', include(router.urls)),                   # API nested under /api/
+    path('api/', include(router.urls)),# API nested under /api/
+    path('api/items/autocomplete/', ItemAutocompleteView.as_view(), name='item-autocomplete'),
 ]


### PR DESCRIPTION
Introduced `ItemAutocompleteView` with associated serializer and URL route for searching items by name. Adjusted OpenAPI schema tagging in `AuthViewSet` and associated methods for better organization. Updated permissions and imports to support new functionality.

[Task v Kanbanite](https://tree.taiga.io/project/justteshi-solar-cargo-app/us/27?kanban-include_attachments=1&kanban-include_tasks=1&kanban-status=10282824)