### PR TITLE
Set default value for `items_input` in DeliveryReportSerializer

### DIFF
--- a/backend/reports/serializers.py
+++ b/backend/reports/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from .models import DeliveryReport, Item, DeliveryReportItem, DeliveryReportImage
+from drf_spectacular.utils import extend_schema_field
 import json
 
 # Delivery Report Item
@@ -27,9 +28,13 @@ class DeliveryReportImageSerializer(serializers.ModelSerializer):
 # End Delivery Report Images Serializer
 
 
-
 class DeliveryReportSerializer(serializers.ModelSerializer):
-    items_input = serializers.CharField(write_only=True, required=False, help_text='JSON array of items to create.')
+    items_input = serializers.CharField(
+        write_only=True,
+        required=False,
+        help_text='JSON array of items to create.',
+        default='[]',  # 👈 Swagger default input
+    )
     items = serializers.SerializerMethodField(read_only=True)
 
     additional_images_input = serializers.ListField(


### PR DESCRIPTION
Added a default value of an empty JSON array (`'[]'`) for the `items_input` field to enhance usability and improve Swagger documentation. This ensures compatibility with API consumers expecting a default schema. Additionally, imported `extend_schema_field` for potential future use in schema extensions.

[Task u Kanbanite](https://tree.taiga.io/project/justteshi-solar-cargo-app/us/24?kanban-include_attachments=1&kanban-include_tasks=1&kanban-status=10282826)