### PR TITLE
Restrict allowed HTTP methods in report views.

### DIFF
--- a/backend/reports/views.py
+++ b/backend/reports/views.py
@@ -17,6 +17,7 @@ class DeliveryReportViewSet(viewsets.ModelViewSet):
     parser_classes = (MultiPartParser, FormParser)
     permission_classes = [IsAuthenticated, IsAdmin]
     pagination_class = ReportsResultsSetPagination
+    http_method_names = ['get', 'post', 'put', 'patch']
 
     @extend_schema(
         tags=["Delivery Reports"],


### PR DESCRIPTION
Add `http_method_names` to explicitly define supported methods for the report views. This enhances security and clarity by limiting unexpected or unsupported HTTP requests.

[Kanbani](https://tree.taiga.io/project/justteshi-solar-cargo-app/us/23?kanban-include_attachments=1&kanban-include_tasks=1&kanban-status=10282826)