### PR TITLE
Increase request line and field size limits in Gunicorn config.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       sh -c "export PYTHONPATH=/code/backend &&
              python /wait-for-db.py &&
              if [ \"$DJANGO_ENV\" = 'prod' ]; then
-               gunicorn config.wsgi:application --bind 0.0.0.0:5000 --timeout 120 --limit-request-line 8190 --limit-request-field_size 8190;
+               gunicorn config.wsgi:application --bind 0.0.0.0:5000 --timeout 120 --limit-request-line 16384 --limit-request-field_size 16384;
              else
                python backend/manage.py runserver 0.0.0.0:5000;
              fi"


### PR DESCRIPTION
Updated the Gunicorn configuration to double the limits for request line and field size, increasing them from 8190 to 16384. This change ensures support for larger requests without hitting size restrictions.