### PR TITLE
Handle missing S3 objects in `PrivateMediaStorage`

### DIFF
--- a/backend/reports/utils/private_storage.py
+++ b/backend/reports/utils/private_storage.py
@@ -1,6 +1,7 @@
 from storages.backends.s3boto3 import S3Boto3Storage
 import boto3
 from django.conf import settings
+from botocore.exceptions import ClientError
 
 class PrivateMediaStorage(S3Boto3Storage):
     default_acl = 'private'
@@ -13,6 +14,20 @@ class PrivateMediaStorage(S3Boto3Storage):
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
             region_name=settings.AWS_S3_REGION_NAME,
         )
+
+        try:
+            # HEAD request to check if the object exists
+            client.head_object(Bucket=self.bucket_name, Key=name)
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            if error_code == '404':
+                # Object does not exist
+                return None
+            else:
+                # Other unexpected S3 error
+                raise
+
+        # If it exists, generate the presigned URL
         return client.generate_presigned_url(
             'get_object',
             Params={'Bucket': self.bucket_name, 'Key': name},


### PR DESCRIPTION
Added error handling for `ClientError` in `PrivateMediaStorage.get_s3_url` to properly handle cases where the requested S3 object does not exist.